### PR TITLE
Handle missing env vars gracefully

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,9 +12,15 @@ import random  # Добавляем для случайного выбора
 load_dotenv()
 
 # Получение токенов и данных из переменных окружения
-GIGACHAT_AUTH_KEY = os.getenv("GIGACHAT_AUTH_KEY").strip()
+GIGACHAT_AUTH_KEY = os.getenv("GIGACHAT_AUTH_KEY")
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 GIGACHAT_SCOPE = os.getenv("GIGACHAT_SCOPE", "GIGACHAT_API_PERS")  # Значение по умолчанию
+
+# Удаляем лишние пробелы, если переменные заданы
+if GIGACHAT_AUTH_KEY:
+    GIGACHAT_AUTH_KEY = GIGACHAT_AUTH_KEY.strip()
+if TELEGRAM_TOKEN:
+    TELEGRAM_TOKEN = TELEGRAM_TOKEN.strip()
 
 # Проверка, что токены загружены
 if not GIGACHAT_AUTH_KEY or not TELEGRAM_TOKEN:

--- a/bot_agressive_caching.py
+++ b/bot_agressive_caching.py
@@ -11,9 +11,15 @@ import uuid
 load_dotenv()
 
 # Получение токенов и данных из переменных окружения
-GIGACHAT_AUTH_KEY = os.getenv("GIGACHAT_AUTH_KEY").strip()
+GIGACHAT_AUTH_KEY = os.getenv("GIGACHAT_AUTH_KEY")
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 GIGACHAT_SCOPE = os.getenv("GIGACHAT_SCOPE", "GIGACHAT_API_PERS")  # Значение по умолчанию, если не указано
+
+# Удаляем лишние пробелы, если переменные заданы
+if GIGACHAT_AUTH_KEY:
+    GIGACHAT_AUTH_KEY = GIGACHAT_AUTH_KEY.strip()
+if TELEGRAM_TOKEN:
+    TELEGRAM_TOKEN = TELEGRAM_TOKEN.strip()
 
 # Проверка, что токены загружены
 if not GIGACHAT_AUTH_KEY or not TELEGRAM_TOKEN:


### PR DESCRIPTION
## Summary
- Avoid calling `.strip()` on undefined environment variables
- Remove trailing whitespace from both auth and Telegram tokens when available

## Testing
- `python -m py_compile bot.py bot_agressive_caching.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4a654b1d483328f67a7e4be91143e